### PR TITLE
Feature/pipedrive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ shelf.db
 .will_codebases
 
 .DS_Store
+
+sample_pipeline.json

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 # Welcome to Will's settings.
-# 
+#
 # All of the settings here can also be specified in the environment, and should be for
-# keys and the like.  In case of conflict, you will see a warning message, and the 
+# keys and the like.  In case of conflict, you will see a warning message, and the
 # value in this file will win.
 
 
@@ -10,12 +10,12 @@
 # ------------------------------------------------------------------------------------
 
 
-# The list of plugin modules will should load. 
+# The list of plugin modules will should load.
 # Will recursively loads all plugins contained in each module.
 
 
 # This list can contain:
-# 
+#
 # Built-in core plugins:
 # ----------------------
 # All built-in modules:     will.plugins
@@ -27,7 +27,7 @@
 # All modules:              plugins
 # A specific module:        plugins.module_name
 # Specific plugins:         plugins.module_name.plugin
-# 
+#
 # Plugins anywhere else on your PYTHONPATH:
 # -----------------------------------------
 # All modules:              someapp
@@ -36,7 +36,7 @@
 
 
 # By default, the list below includes all the core will plugins and
-# all your project's plugins.  
+# all your project's plugins.
 
 PLUGINS = [
     # Built-ins
@@ -88,9 +88,15 @@ if not "DEV_ENV" in os.environ:
     DEFAULT_ROOM = 'Everybody Everyone!'
 
 
-# Fully-qualified folders to look for templates in, beyond the two that 
+# Pipedrive Config
+PIPEDRIVE_PIPELINE_WHITELIST = [1, 7]
+PIPEDRIVE_STAGE_BLACKLIST = [2, 5]
+
+
+
+# Fully-qualified folders to look for templates in, beyond the two that
 # are always included: core will's templates folder, and your project's templates folder.
-# 
+#
 # TEMPLATE_DIRS = [
 #   os.path.abspath("other_folder/templates")
 # ]

--- a/plugins/biz/pipedrive.py
+++ b/plugins/biz/pipedrive.py
@@ -47,7 +47,7 @@ class PipedrivePlugin(WillPlugin):
         print "\n\n\n", pipedrive_users, "\n\n\n"
         body = self.request.json
         payload = {
-            'name': pipedrive_users.get(body['current']['creator_user_id'], 'Unkown Sales Agent'),
+            'name': pipedrive_users.get(body['current']['creator_user_id'], {}).get('name', 'Unknown Sales Agent'),
             'from_stage': body['previous']['stage_id'],
             'to_stage': body['current']['stage_id'],
             'title': body['current']['title'],

--- a/plugins/biz/pipedrive.py
+++ b/plugins/biz/pipedrive.py
@@ -1,6 +1,20 @@
-"""Pipedrive CRM Plugin for Will.
+"""Pipedrive CRM Web Hook Push Notification Plugin for Will.
 
-Requries settings.PIPEDRIVE_KEY which can be set in the OS enviroment as WILL_PIPEDRIVE_KEY
+Quickstart
+    To use the Pipedrive Plugin:
+        1. set your Pipedrive API Key in your env or Will's config.py as PIPEDRIVE_KEY or (recommended)in the
+        environment as WILL_PIPEDRIVE_KEY
+        2. create a push notification subscription at https://<your-org>.pipedrive.com/push_notifications/index#
+        3. add any pipelines or stages to the whitelists and blacklists below in config.py by id
+            - ex. PIPEDRIVE_PIPELINE_WHITELIST = [1, 7]
+
+    Will will notify its default chat room when a deal is moved from one stage to another, won, or lost.
+
+Optional config.py settings:
+    PIPEDRIVE_PIPELINE_WHITELIST - only pipeline ids on the whitelist trigger notifications
+    PIPEDRIVE_STAGE_WHITELIST - only stages on the whiltelist will trigger notifications
+    PIPEDRIVE_PIPELINE_BLACKLIST - pipeline ids on the blacklist will not trigger notifications (overides whitelist)
+    PIPEDRIVE_STAGE_BLACKLIST - stage ids on the blacklist will not trigger notifications (overides whitelist)
 """
 
 import requests
@@ -61,16 +75,16 @@ class PipedrivePlugin(WillPlugin):
             'pipeline': pipelines.get(body['current']['pipeline_id'], {}).get('name'),
         }
 
-        if self._pipedrive_deal_stage_changed(body):
-            message = rendered_template("pipedrive_update.html", context=payload)
+        if self._pipedrive_deal_status_won(body):
+            message = rendered_template("pipedrive_won.html", context=payload)
             self.say(message, html=True, color="green")
 
-        if self._pipedrive_deal_status_lost(body):
+        elif self._pipedrive_deal_status_lost(body):
             message = rendered_template("pipedrive_lost.html", context=payload)
             self.say(message, html=True, color="red")
 
-        if self._pipedrive_deal_status_won(body):
-            message = rendered_template("pipedrive_won.html", context=payload)
+        elif self._pipedrive_deal_stage_changed(body):
+            message = rendered_template("pipedrive_update.html", context=payload)
             self.say(message, html=True, color="green")
 
         return 'OK'

--- a/plugins/biz/pipedrive.py
+++ b/plugins/biz/pipedrive.py
@@ -129,7 +129,7 @@ class PipedrivePlugin(WillPlugin):
 
     @periodic(hour='1', minute='0', day_of_week="mon-fri")
     def update_pipedrive_users(self):
-        """Update the cached list of Pipedrive users (user_id) periodically."""
+        """Get and store pipedrive users."""
         self._raise_for_missing_pipedrive_key()
         url = 'https://api.pipedrive.com/v1/users'
         resp = requests.get(url, params={'api_token': settings.PIPEDRIVE_KEY})
@@ -148,7 +148,7 @@ class PipedrivePlugin(WillPlugin):
 
     @periodic(hour='1', minute='10', day_of_week="mon-fri")
     def update_pipedrive_stages(self):
-        """Get pipedrive stages from storgage or API."""
+        """Get and store pipedrive stages."""
         self._raise_for_missing_pipedrive_key()
         pipeline_ids = self.pipedrive_pipelines.keys()
         pipedrive_stages = {
@@ -160,7 +160,7 @@ class PipedrivePlugin(WillPlugin):
         self._pipedrive_stages = pipedrive_stages
 
     def update_pipedrive_pipelines(self):
-        """Get pipedrive pipelines from storgage or API."""
+        """Get and store pipedrive pipelines."""
         self._raise_for_missing_pipedrive_key()
         url = 'https://api.pipedrive.com/v1/pipelines'
         resp = requests.get(url, params={'api_token': settings.PIPEDRIVE_KEY})

--- a/plugins/biz/pipedrive.py
+++ b/plugins/biz/pipedrive.py
@@ -1,0 +1,49 @@
+"""Pipedrive CRM Plugin for Will."""
+
+from will.plugin import WillPlugin
+from will.decorators import (
+    periodic,
+    rendered_template,
+    route,
+)
+
+
+class PipedrivePlugin(WillPlugin):
+    """A Will plugin for BuddyUp's CRM Pipedrive's webhooks."""
+
+    def _pipedrive_deal_stage_changed(self, payload):
+        return payload['current']['stage_id'] != payload['previous']['stage_id']
+
+    @route("/api/pipedrive-update", method="POST")
+    def pipedrive_notification(self):
+        """Web hook push notification endpoint from Pipedrive subscription(s) when a deal moves.
+
+        https://developers.pipedrive.com/v1#methods-PushNotifications / REST Hooks / Web hooks
+        """
+        print self.request.json
+        assert self.request.json and "current" in self.request.json and "previous" in self.request.json
+        pipedrive_users = self.load('pipedrive_users') or {}
+        body = self.request.json
+
+        if not self._pipedrive_deal_stage_changed(body):
+            return 'OK'
+
+        payload = {
+            'name': pipedrive_users.get(body['current']['creator_user_id'], 'Unkown Sales Agent'),
+            'status': body['current'].get('status'),
+            'from_stage': body['previous']['stage_id'],
+            'to_stage': body['current']['stage_id'],
+            'title': body['current']['title'],
+        }
+        message = rendered_template("pipeline_update.html", context=payload)
+        color = "green"
+        self.say(message, html=True, color=color)
+        self.say("(boom)", color=color)
+
+        return 'OK'
+
+    @periodic(hour='1', minute='0', day_of_week="mon-fri")
+    def update_pipedrive_users(self):
+        """Update the cached list of Pipedrive users (user_id) periodically."""
+        pipedrive_users = {}
+        self.save('pipedrive_users', pipedrive_users)

--- a/plugins/biz/pipedrive.py
+++ b/plugins/biz/pipedrive.py
@@ -45,7 +45,7 @@ class PipedrivePlugin(WillPlugin):
         assert self.request.json and "current" in self.request.json and "previous" in self.request.json
         pipedrive_users = self.pipedrive_users
         stages = self.pipedrive_stages
-        print "\n\n\n Stages: ", stages, "\n\n\n"
+        pipelines = self.pipedrive_pipelines
         body = self.request.json
 
         user = pipedrive_users.get(body['current']['creator_user_id'])
@@ -55,9 +55,10 @@ class PipedrivePlugin(WillPlugin):
 
         payload = {
             'name': user.get('name', 'Unknown Sales Agent'),
-            'from_stage': body['previous']['stage_id'],
-            'to_stage': body['current']['stage_id'],
+            'from_stage': stages.get(body['previous']['stage_id'], {}).get('name'),
+            'to_stage': stages.get(body['current']['stage_id'], {}).get('name'),
             'title': body['current']['title'],
+            'pipeline': pipelines.get(body['current']['pipeline_id'], {}).get('name'),
         }
 
         if self._pipedrive_deal_stage_changed(body):
@@ -104,7 +105,7 @@ class PipedrivePlugin(WillPlugin):
             for stage in self._fetch_stages_for_pipeline(p_id)
         }
         self.save('pipedrive_stages', pipedrive_stages)
-        self._pipdrive_stages = pipedrive_stages
+        self._pipedrive_stages = pipedrive_stages
 
     def update_pipedrive_pipelines(self):
         """Get pipedrive pipelines from storgage or API."""

--- a/plugins/biz/pipedrive.py
+++ b/plugins/biz/pipedrive.py
@@ -30,7 +30,6 @@ class PipedrivePlugin(WillPlugin):
 
         payload = {
             'name': pipedrive_users.get(body['current']['creator_user_id'], 'Unkown Sales Agent'),
-            'status': body['current'].get('status'),
             'from_stage': body['previous']['stage_id'],
             'to_stage': body['current']['stage_id'],
             'title': body['current']['title'],
@@ -46,4 +45,12 @@ class PipedrivePlugin(WillPlugin):
     def update_pipedrive_users(self):
         """Update the cached list of Pipedrive users (user_id) periodically."""
         pipedrive_users = {}
+        # TODO ALECK: Get these from the pipedrive API.
         self.save('pipedrive_users', pipedrive_users)
+
+    @periodic(hour='1', minute='10', day_of_week="mon-fri")
+    def update_pipedrive_stages(self):
+        """Update the cached list of Pipedrive users (user_id) periodically."""
+        pipedrive_stages = {}
+        # TODO ALECK: Get these from the pipedrive API.
+        self.save('pipedrive_stages', pipedrive_stages)

--- a/plugins/culture/code_flow.py
+++ b/plugins/culture/code_flow.py
@@ -6,7 +6,7 @@ class CodeFlowPlugin(WillPlugin):
 
     @respond_to("CR (?:for )?(?P<pr_id>\d*)$")
     def cr(self, message, pr_id):
-        """cr ___: Post a link to buddyup CR #___""" 
+        """cr ___: Post a link to buddyup CR #___"""
         self.say("@all (crrequest) https://github.com/buddyup/core/pull/%s" % pr_id, message=message)
 
     @respond_to("CR (?:for )?(?P<pr_id>\d*) g2g$")
@@ -17,7 +17,7 @@ class CodeFlowPlugin(WillPlugin):
 
     @respond_to("FR (?:for )?(?P<pr_id>\d*)$")
     def fr(self, message, pr_id):
-        """fr ___: Post a link to buddyup FR #___""" 
+        """fr ___: Post a link to buddyup FR #___"""
         self.say("@all (frrequest) https://github.com/buddyup/core/pull/%s" % pr_id, message=message)
 
     @respond_to("FR (?:for )?(?P<pr_id>\d*) g2g$")

--- a/templates/pipedrive_lost.html
+++ b/templates/pipedrive_lost.html
@@ -1,0 +1,2 @@
+Sales update! <b>{{ name }}</b> lost to the deal <b>{{ title }}</b>
+<br/><img src="https://s3.amazonaws.com/uploads.hipchat.com/183747/2580355/t34p8XC4BHrTrHZ/upload.png" alt=""  height="200"/>

--- a/templates/pipedrive_update.html
+++ b/templates/pipedrive_update.html
@@ -1,2 +1,2 @@
 Sales update! <img src="https://dujrsrsgsd3nh.cloudfront.net/img/emoticons/boom-1414103101.gif" width="30" height="30"> <br/>
-<b>{{ name }}</b> moved to the deal <b>{{ title }}</b> from stage <b>{{ from_stage }}</b> to stage <b>{{ to_stage }}</b>
+<b>{{ name }}</b> moved <b>{{ title }}</b> from stage <b>{{ from_stage }}</b> to stage <b>{{ to_stage }}</b>

--- a/templates/pipedrive_update.html
+++ b/templates/pipedrive_update.html
@@ -1,2 +1,2 @@
 Sales update! <img src="https://dujrsrsgsd3nh.cloudfront.net/img/emoticons/boom-1414103101.gif" width="30" height="30"> <br/>
-<b>{{ name }}</b> moved to the deal <b>{{ title }}</b> from stage <b>{{ from_stage }}</b> to <b>stage {{ to_stage }}</b>
+<b>{{ name }}</b> moved to the deal <b>{{ title }}</b> from stage <b>{{ from_stage }}</b> to stage <b>{{ to_stage }}</b>

--- a/templates/pipedrive_update.html
+++ b/templates/pipedrive_update.html
@@ -1,0 +1,2 @@
+Sales update! <img src="https://dujrsrsgsd3nh.cloudfront.net/img/emoticons/boom-1414103101.gif" width="30" height="30"> <br/>
+<b>{{ name }}</b> moved to the deal <b>{{ title }}</b> from stage <b>{{ from_stage }}</b> to <b>stage {{ to_stage }}</b>

--- a/templates/pipedrive_won.html
+++ b/templates/pipedrive_won.html
@@ -1,0 +1,4 @@
+Sales update! <img src="https://dujrsrsgsd3nh.cloudfront.net/img/emoticons/boom-1414103101.gif" width="30" height="30"> <br/>
+<b>{{ name }}</b> won to the deal <b>{{ title }}</b>
+<br/>
+<img src="https://s3.amazonaws.com/uploads.hipchat.com/183747/3575947/3l2DoKbTRW1pRFc/celebration.gif" alt="" />

--- a/templates/pipeline_update.html
+++ b/templates/pipeline_update.html
@@ -1,1 +1,0 @@
-Sales update! <b>{{ name }}</b> moved to the deal <b>{{ title }}</b> from stage <b>{{ from_stage }}</b> to <b>stage {{ to_stage }}</b>

--- a/templates/pipeline_update.html
+++ b/templates/pipeline_update.html
@@ -1,0 +1,1 @@
+Sales update! <b>{{ name }}</b> moved to the deal <b>{{ title }}</b> from stage <b>{{ from_stage }}</b> to <b>stage {{ to_stage }}</b>


### PR DESCRIPTION
Pipedrive CRM Web Hook Push Notification Plugin for Will.

Quickstart
    To use the Pipedrive Plugin:
        1. set your Pipedrive API Key in your env or Will's config.py as PIPEDRIVE_KEY or (recommended)in the
        environment as WILL_PIPEDRIVE_KEY
        2. create a push notification subscription at https://<your-org>.pipedrive.com/push_notifications/index#
        3. add any pipelines or stages to the whitelists and blacklists below in config.py by id
            - ex. PIPEDRIVE_PIPELINE_WHITELIST = [1, 7]

```
Will will notify its default chat room when a deal is moved from one stage to another, won, or lost.
```

Optional config.py settings:
    PIPEDRIVE_PIPELINE_WHITELIST - only pipeline ids on the whitelist trigger notifications
    PIPEDRIVE_STAGE_WHITELIST - only stages on the whiltelist will trigger notifications
    PIPEDRIVE_PIPELINE_BLACKLIST - pipeline ids on the blacklist will not trigger notifications (overides whitelist)
    PIPEDRIVE_STAGE_BLACKLIST - stage ids on the blacklist will not trigger notifications (overides whitelist)

![image](https://cloud.githubusercontent.com/assets/2336595/13830770/1272ade6-eb8c-11e5-8588-e1caaa56473a.png)
